### PR TITLE
Update for Convex 0.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,15 @@ version = "0.1.0"
 [deps]
 Convex = "f65535da-76fb-5f13-bab9-19810c17039a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-MathProgBase = "fdba3010-5040-5b88-9595-932c9decdf73"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Convex = "0.12"
 julia = "1"
 
 [extras]
+SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["SCS", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-Convex = "0.12"
+Convex = "0.13"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -67,11 +67,17 @@ bc = BilinearConstraint(x,1.,x,y-z,X=-x0,Y=-x0,λ=λ)
 bp = BilinearProblem(p,bc)
 
 # Call the solve!() function on the bilinear problem
-r = solve!(bp,SCSSolver(verbose=0),iterations=2)
+r = solve!(bp,() -> SCS.Optimizer(verbose=0),iterations=2)
 
 # Use Convex.jl to inspect the result. It turns out to be the global minimizer
 xopt = evaluate(x)
 yopt = evaluate(y)
+```
+
+To solve the problem with `Mosek` instead, replace the `solve!` call above with
+```julia
+using MosekTools
+r = solve!(bp,() -> Mosek.Optimizer(QUIET=true),iterations=2)
 ```
 
 For more examples, check the files in the 'examples' folder. It contains an interactive demo of exactly what the method does, an interactive demo with the Rosenbrock function and a demo on solving a sudoku puzzle.
@@ -129,6 +135,6 @@ The software:
 # Compatibility issues
 Currently Convex.jl and many solvers are in a process to switch to different optimization interface packages, which might break this package's functionality.
 Currently the tested versions are:
-- Convex.jl v0.12.4
-- Mosek.jl v0.9.11
-- SCS.jl v0.6.0
+- Convex.jl v0.13.1
+- MosekTools.jl v0.9.3
+- SCS.jl v0.6.6

--- a/src/SequentialConvexRelaxation.jl
+++ b/src/SequentialConvexRelaxation.jl
@@ -5,7 +5,6 @@ module SequentialConvexRelaxation
 using Convex
 import Convex.solve!
 using LinearAlgebra
-import MathProgBase
 
 export solve!, BConstraint, BilinearProblem, BilinearConstraint, BinaryConstraint
 
@@ -278,7 +277,7 @@ end
 
 """
     solve!(bilinearproblem::BilinearProblem,
-        solver::MathProgBase.AbstractMathProgSolver;
+        solver;
         iterations::Int=1,
         trackvariables::Tuple{Vararg{AbstractExpr}}=tuple(),
         update_weights::Bool=false,
@@ -313,7 +312,7 @@ Think of it as a reweighted regularization ||W1(C-APB)W2||, where W1 and W2 are 
 E := C-APB, W1 = inv(E*E' + γ*I), W2 = inv(E'*E + γ*I), γ = weight_update_tuning_param > 0.
 """
 function solve!(bilinearproblem::BilinearProblem,
-    solver::MathProgBase.AbstractMathProgSolver;
+    solver;
     iterations::Int=1,        # SCR iterations
     trackvariables::Tuple{Vararg{AbstractExpr}}=tuple(),
     update_weights::Bool=false,

--- a/src/SequentialConvexRelaxation.jl
+++ b/src/SequentialConvexRelaxation.jl
@@ -3,6 +3,7 @@ module SequentialConvexRelaxation
 # Reinier Doelman, 2/9/2019
 
 using Convex
+using Convex: AbstractExpr
 import Convex.solve!
 using LinearAlgebra
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,11 @@ using LinearAlgebra
 using SCS
 using Random
 Random.seed!(123)
-
 solver() = SCS.Optimizer(verbose=0)
+
+# To test with Mosek
+# using MosekTools
+# solver() = Mosek.Optimizer(QUIET=true)
 
 @testset "SequentialConvexRelaxation.jl" begin
     A = Variable()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ using SCS
 using Random
 Random.seed!(123)
 
+solver() = SCS.Optimizer(verbose=0)
+
 @testset "SequentialConvexRelaxation.jl" begin
     A = Variable()
     B = Variable()
@@ -54,7 +56,7 @@ Random.seed!(123)
             bc1 = BilinearConstraint(A,P,B,D,X=X,Y=Y)
             problem = minimize(0.)
             bp = BilinearProblem(problem,bc1)
-            SequentialConvexRelaxation.solve!(bp,SCSSolver(verbose=0),iterations=3)
+            SequentialConvexRelaxation.solve!(bp,solver,iterations=3)
             @test bp.result.iterations == 3
             @test bp.result.update_weights == false
             @test bp.result.constraint_violations[1][1] <= 1E-5
@@ -66,7 +68,7 @@ Random.seed!(123)
             problem = minimize(0.)
             bc2 = BilinearConstraint(A,P,B,D,X=60*X,Y=60*X)
             bp = BilinearProblem(problem,bc2)
-            SequentialConvexRelaxation.solve!(bp,SCSSolver(verbose=0),iterations=5)
+            SequentialConvexRelaxation.solve!(bp,solver,iterations=5)
             @test bp.result.iterations == 5
             @test bp.result.update_weights == false
             @test bp.result.constraint_violations[end][1] <= 1E-3
@@ -78,7 +80,7 @@ Random.seed!(123)
             problem = minimize(0.)
             bc2 = BilinearConstraint(A,P,B,D,X=20*X,Y=20*X)
             bp = BilinearProblem(problem,bc2)
-            r = SequentialConvexRelaxation.solve!(bp,SCSSolver(verbose=0),trackvariables=(A, B),iterations=4)
+            r = SequentialConvexRelaxation.solve!(bp,solver,trackvariables=(A, B),iterations=4)
             @test !isempty(bp.result.tracked_variables_values)
         end
 
@@ -88,7 +90,7 @@ Random.seed!(123)
             B = ComplexVariable()
             bc2 = BilinearConstraint(A,P,B,D,X=0.1+0.1im,Y=0.3-0.2im)
             bp = BilinearProblem(problem,bc2)
-            r = SequentialConvexRelaxation.solve!(bp,SCSSolver(verbose=0),trackvariables=(A, B),iterations=7)
+            r = SequentialConvexRelaxation.solve!(bp,solver,trackvariables=(A, B),iterations=7)
             @test !isempty(bp.result.tracked_variables_values)
             @test norm(evaluate(A)*evaluate(B) - 1.) <= 1E-3
         end
@@ -100,7 +102,7 @@ Random.seed!(123)
             D = rand(2)*rand(2)'
             bc2 = BilinearConstraint(A,1.,B,D)
             bp = BilinearProblem(problem,bc2)
-            r = SequentialConvexRelaxation.solve!(bp,SCSSolver(verbose=0),trackvariables=(A, B),iterations=3)
+            r = SequentialConvexRelaxation.solve!(bp,solver,trackvariables=(A, B),iterations=3)
             @test !isempty(bp.result.tracked_variables_values)
             @test norm(evaluate(A)*evaluate(B) - D) <= 1E-4
         end


### PR DESCRIPTION
This looks cool! I wanted to help update it for the new release of Convex.jl. The first commit just cleans up the Project.toml file a bit by adding compat, moving SCS to be a test-only dependency (since it's not needed in the source code), and removing the MathProgBase dependency, which is only used for type-annotating the `solver` argument for `solve!`. This isn't necessary and it turns out to be one of only two issues preventing the package from working with Convex 0.13 (which uses MOI optimizers instead, like `SCS.Optimizer` instead of `SCSSolver`).

The second commit makes the other change needed for Convex 0.13 compatibility:  `AbstractExpr` is no longer exported from Convex.jl, so that needs to be pulled into the namespace (i.e. imported or `using Convex: AbstractExpr` as I did here). I also updated the tests to use MOI optimizers, and updated the compat again. Theoretically, the compat `0.12, 0.13` would work and allow this package to be used with both Convex 0.12 and 0.13. The trouble is that the tests need a specific version to know what type of optimizer to use. So I just put 0.13 alone, but you could change that.

I also updated the README to use the MOI optimizer syntax.